### PR TITLE
Replace cp with rsync in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
-	cp -r . /usr/local/lib/icomoon-swift
+	rsync -r . /usr/local/lib/icomoon-swift
 	chmod +x run.sh
-	cp run.sh /usr/local/bin/icomoon-swift
+	rsync run.sh /usr/local/bin/icomoon-swift
 
 uninstall:
 	rm -rf /usr/local/lib/icomoon-swift


### PR DESCRIPTION
The existing makefile uses `cp` but assumes that it is the GNU version of the command, which is not the default version included on OSX. The default version of `cp` doesn't handle path creation correctly, and fails.

`rsync` handles path creation as expected, and is (AFAIK) bundled with OSX by default.
